### PR TITLE
feat: add ability to configure cors in the config

### DIFF
--- a/internal/cmd/config/cmd.go
+++ b/internal/cmd/config/cmd.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"io/ioutil"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 
@@ -12,11 +13,25 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type CorsConfig struct {
+	AllowedOrigins         []string                                  `yaml:"allowed-origins"`
+	AllowOriginFunc        func(origin string) bool                  `yaml:"allow-origin-func"`
+	AllowOriginRequestFunc func(r *http.Request, origin string) bool `yaml:"allow-origin-request-func"`
+	AllowedMethods         []string                                  `yaml:"allowed-methods"`
+	AllowedHeaders         []string                                  `yaml:"allowed-headers"`
+	ExposedHeaders         []string                                  `yaml:"exposed-headers"`
+	MaxAge                 int                                       `yaml:"max-age"`
+	AllowCredentials       bool                                      `yaml:"allow-credentials"`
+	OptionsPassthrough     bool                                      `yaml:"options-passthrough"`
+	Debug                  bool                                      `yaml:"debug"`
+}
+
 type Config struct {
 	Server         *httptest.Server `yaml:"-"`
 	Gateway        *gateway.Gateway `yaml:"-"`
 	Listen         string           `yaml:"listen"`
 	gateway.Config `yaml:"-,inline"`
+	CorsConfig     `yaml:"cors"`
 }
 
 var (

--- a/internal/cmd/serve/cmd.go
+++ b/internal/cmd/serve/cmd.go
@@ -191,9 +191,7 @@ func watchFile(filename string, onChange func(in fsnotify.Event)) (*fsnotify.Wat
 
 func startServer(config *config.Config) error {
 	postProcess(config)
-	c := cors.New(cors.Options{
-		AllowedOrigins: []string{"*"},
-	})
+	c := cors.New((cors.Options)(config.CorsConfig))
 	mux := http.NewServeMux()
 	handler := c.Handler(mux)
 	server, err := gateway.StartHttpListener(config.Listen, handler)


### PR DESCRIPTION
Fixes #58 
Through this PR, I have tried to add the functionality that enables CORS to be configured through the `graphql-link.yaml` file.